### PR TITLE
Allowed Origins の正規化方法の変更 - パスは含めない

### DIFF
--- a/src/libs/normalize-origins.test.ts
+++ b/src/libs/normalize-origins.test.ts
@@ -34,7 +34,7 @@ describe('allowed origin normalizer', () => {
   it('should normalize URL with port, dirctory, querystring and hash.', () => {
     const input = ['https://example.com:8000/hello/world?query=hello#aaaaa'].join('\n');
     const output = normalizeOrigins(input);
-    expect(output).toEqual(['https://example.com:8000/hello/world?query=hello#aaaaa']);
+    expect(output).toEqual(['https://example.com:8000']);
   });
 
   it('should normalize localhost', () => {

--- a/src/libs/normalize-origins.ts
+++ b/src/libs/normalize-origins.ts
@@ -16,12 +16,9 @@ export const normalizeOrigins = (lineDelimetedAllowedOrigins: string) => {
         prev.add(origin);
       } else {
         try {
-          const { groups: { protocol, hostAndPort, directory } } = (urlPattern.exec(origin) || {}) as { groups: { protocol: any, hostAndPort: any, directory: any } };
+          const { groups: { protocol, hostAndPort } } = (urlPattern.exec(origin) || {}) as { groups: { protocol: any, hostAndPort: any, directory: any } };
           if (protocol && hostAndPort) {
-            let origin = `${protocol}://${hostAndPort}`;
-            if (directory && directory !== '/') {
-              origin += directory;
-            }
+            const origin = `${protocol}://${hostAndPort}`;
             prev.add(origin);
           }
         } catch (_e) {


### PR DESCRIPTION
app.geolonia.com に使っている `normalizeOrigins` の関数ですが、サーバー側でも使っているためこれを切り出しました。

関連タスク: https://github.com/geolonia/tasks-dev/issues/42

https://github.com/geolonia/app.geolonia.com/issues/582 の対応はこちらのリポジトリで行いたいと思います。

この修正では、URLリストとして入力されたテキストをオリジンのリストに正規化する際にパス部分を含めないようにしています。

